### PR TITLE
lower minimum version of R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: janeaustenr
 Title: An R Package for Jane Austen's Complete Novels
-Version: 0.0.0.9000
+Version: 0.0.1.9000
 Authors@R: person("Julia", "Silge", email = "julia.silge@gmail.com", role = c("aut", "cre"))
 Description: Full texts for Jane Austen's 6 completed novels, ready for text
     analysis. These novels are "Sense and Sensibility", "Pride and Prejudice",
     "Mansfield Park", "Emma", "Northanger Abbey", and "Persuasion".
 Depends:
-    R (>= 3.2.3)
+    R (>= 3.1.2)
 License: GPL-3
 LazyData: true
 RoxygenNote: 5.0.1


### PR DESCRIPTION
I want to use your excellent collection of Austen's novels in a teaching environment that only has R v3.1.2.  I don't think there's any particular reason why a higher version is needed, so can we lower the minimum version in case others have similar issues.
