### PR TITLE
lazy-loaded data are not in the package namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-
 language: R
 cache: packages
-
+latex: false

--- a/R/austen_books.R
+++ b/R/austen_books.R
@@ -24,12 +24,12 @@
 #' @export
 austen_books <- function(){
         books <- list(
-                "Sense & Sensibility" = sensesensibility,
-                "Pride & Prejudice" = prideprejudice,
-                "Mansfield Park" = mansfieldpark,
-                "Emma" = emma,
-                "Northanger Abbey" = northangerabbey,
-                "Persuasion" = persuasion
+                "Sense & Sensibility" = janeaustenr::sensesensibility,
+                "Pride & Prejudice" = janeaustenr::prideprejudice,
+                "Mansfield Park" = janeaustenr::mansfieldpark,
+                "Emma" = janeaustenr::emma,
+                "Northanger Abbey" = janeaustenr::northangerabbey,
+                "Persuasion" = janeaustenr::persuasion
         )
        ret <- data.frame(text = unlist(books, use.names = FALSE), 
                          stringsAsFactors = FALSE)


### PR DESCRIPTION
Currently, this gives an error:

```
> books <- janeaustenr::austen_books()
Error in janeaustenr::austen_books() : 
  object 'sensesensibility' not found
```

The issue is that [lazy-loaded data are not in the package namespace](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#FOOT58)

This patch puts `janeaustenr::` before the lazy data objects.