### PR TITLE
Remove dplyr as dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,7 @@ Description: Full texts for Jane Austen's 6 completed novels, ready for text
 URL: https://github.com/juliasilge/janeaustenr
 BugReports: https://github.com/juliasilge/janeaustenr/issues
 Depends: R (>= 3.1.2)
-Suggests: dplyr,
-    testthat
+Suggests: testthat
 License: MIT + file LICENSE
 LazyData: true
 RoxygenNote: 6.0.1

--- a/R/austen_books.R
+++ b/R/austen_books.R
@@ -16,10 +16,8 @@
 #' 
 #' @examples 
 #' 
-#' library(dplyr)
-#'
-#' austen_books() %>% group_by(book) %>%
-#'      summarise(total_lines = n())
+#' lines_by_book <- table(austen_books()$book)
+#' lines_by_book
 #'
 #' @export
 austen_books <- function(){

--- a/man/austen_books.Rd
+++ b/man/austen_books.Rd
@@ -23,9 +23,7 @@ caps to indicate italics/emphasis.
 }
 \examples{
 
-library(dplyr)
-
-austen_books() \%>\% group_by(book) \%>\%
-     summarise(total_lines = n())
+lines_by_book <- table(austen_books()$book)
+lines_by_book
 
 }

--- a/tests/testthat/test_austen_books.R
+++ b/tests/testthat/test_austen_books.R
@@ -2,8 +2,6 @@
 
 context("Tidy dataframe for books")
 
-suppressPackageStartupMessages(library(dplyr))
-
 test_that("factor order is correct", {
         d <- austen_books()
         expect_equal(levels(d$book)[1], "Sense & Sensibility")
@@ -11,14 +9,11 @@ test_that("factor order is correct", {
 })
 
 test_that("tidy frame for Austen books is right", {
-        d <- austen_books() %>% 
-                group_by(book) %>%
-                summarise(total_lines = n())
-        expect_equal(nrow(d), 6)
-        expect_equal(ncol(d), 2)
+        lines_by_book <- table(austen_books()$book)
+        expect_length(lines_by_book, 6L)
         # the factor levels still in the right order?
-        expect_equal(as.character(d$book[1]), "Sense & Sensibility")
-        expect_equal(as.character(d$book[6]), "Persuasion")
+        expect_equal(names(lines_by_book)[1L], "Sense & Sensibility")
+        expect_equal(names(lines_by_book)[6L], "Persuasion")
         # Persuasion has fewer lines than Emma?
-        expect_lt(d$total_lines[6], d$total_lines[4])
+        expect_lt(lines_by_book[[6L]], lines_by_book[[4L]])
 })


### PR DESCRIPTION
The dplyr requirement is pretty thin, and can be removed I think.

On the one hand, Suggests aren't required to run the package, but OTOH, they can be required for CI, and for that case dplyr is probably too heavy for many downstream use cases, though to be fair a large plurality of such probably use dplyr in their deps closure already...